### PR TITLE
run containers with the `svn:svnusers` user instead of `root`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,6 @@ WORKDIR /var/opt/svn
 RUN apk add --no-cache \
 	subversion==1.14.3-r2 \
 	wget==1.24.5-r0
+
+# 100:101
+USER svn:svnusers


### PR DESCRIPTION
Instead of running the container as root, it's [generally preferable to run with a different user](https://stackoverflow.com/questions/68155641/should-i-run-things-inside-a-docker-container-as-non-root-for-safety).

The container already contains a `svn` user inside a `svnusers` group:

```shell
/var/opt/svn $ getent passwd
root:x:0:0:root:/root:/bin/sh
...
nobody:x:65534:65534:nobody:/:/sbin/nologin
svn:x:100:101:svn:/var/svn:/sbin/nologin
/var/opt/svn $
```

We can use this user, though I couldn't find information on what this user/group is meant for. Also it's not completely clear if the UID and GID are fixed. It would be troublesome if UID or GID changed in an image update (like it happed with [Tor docker-obfs4-bridge](https://gitlab.torproject.org/tpo/anti-censorship/docker-obfs4-bridge/-/issues/17)).

An alternatively could be to use `USER 100:101` instead of `USER svn:svnusers`.

If we go with one of the above, it might be worth to consider moving the root directory to `/var/svn` (which is owned by `svn:svnusers`) as shown in the `svnserve` docs example.

Another option is to create our own user with a large id.

PS. Just out of curiosity, is there a reason to have the test script in two places (`./test.sh` and `./test/test.sh`)?