### PR TITLE
Output server logs and handle SIGTERM

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Force Unix style line endings for files that will be copied into the Docker image
+*.sh text eol=lf
+
+# Auto detect text files and perform LF normalization on the rest
+* text=auto

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 FROM alpine:3.20.2
 
-COPY docker-entrypoint.sh /
-CMD [ "/docker-entrypoint.sh" ]
 EXPOSE 3690
+
 HEALTHCHECK CMD netstat -ln | grep 3690 || exit 1
+
 VOLUME [ "/var/opt/svn" ]
 WORKDIR /var/opt/svn
 
 RUN apk add --no-cache \
 	subversion==1.14.3-r2 \
 	wget==1.24.5-r0
+
+COPY docker-entrypoint.sh /
+CMD [ "/docker-entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.20.2
 
-CMD [ "/usr/bin/svnserve", "--daemon", "--foreground", "--root", "/var/opt/svn" ]
+COPY docker-entrypoint.sh /
+CMD [ "/docker-entrypoint.sh" ]
 EXPOSE 3690
 HEALTHCHECK CMD netstat -ln | grep 3690 || exit 1
 VOLUME [ "/var/opt/svn" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN apk add --no-cache \
 	wget==1.24.5-r0
 
 COPY docker-entrypoint.sh /
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT docker-entrypoint.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,12 +7,14 @@ rm -f /var/svn/svnlogs
 mkfifo /var/svn/svnlogs
 
 # run the SVN service in the background
-/usr/bin/svnserve --daemon --root /var/opt/svn --log-file=/var/svn/svnlogs &
+/usr/bin/svnserve --daemon --foreground --root /var/opt/svn --log-file=/var/svn/svnlogs &
 # remember the PID of the SVN server
 SVNSERVE_PID=$!
 
-# redirect svnserve logs to stdout
-cat /var/svn/svnlogs
+# redirect SIGTERM to the SVN service
+trap "kill -s SIGTERM $SVNSERVE_PID" SIGTERM
 
-# stop the SVN server running in the background
-kill -s SIGTERM $SVNSERVE_PID
+# redirect svnserve logs to stdout
+while read -r line < /var/svn/svnlogs; do
+	printf '%s\n' "$line"
+done

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+# create a pipe for svnserve logs
+rm -f /var/svn/svnlogs
+mkfifo /var/svn/svnlogs
+
+# run the SVN service in the background
+/usr/bin/svnserve --daemon --root /var/opt/svn --log-file=/var/svn/svnlogs &
+# remember the PID of the SVN server
+SVNSERVE_PID=$!
+
+# redirect svnserve logs to stdout
+cat /var/svn/svnlogs
+
+# stop the SVN server running in the background
+kill -s SIGTERM $SVNSERVE_PID


### PR DESCRIPTION
`svnserve` has the option `--log-file`:

```shell
  --log-file ARG           : svnserve log file
```

I added a `docker-entrypoint.sh` script that creates a named pipe using `mkfifo`, runs `svnserve` in the background and then redirects logs from the named pipe to the stdout for Docker. Once a SIGTERM is received, sends the SIGTERM signal to the `svnserve` in the background.

I also added the `.gitattributes` file, since I'm on Windows git tries to 'fix' line endings to `\r\n` and Docker doesn't like that.

And finally, before the container would never terminate gracefully when stopped, it would always be killed after the grace period. Now, the SIGTERM signal should be correctly forwarded to `svnserve`, which closes the named pipe after it's done, which also breaks the while loop terminating the whole entrypoint script.