### PR TITLE
Pass custom user args to svnserve

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Force Unix style line endings for files that will be copied into the Docker image
+*.sh text eol=lf
+
+# Auto detect text files and perform LF normalization on the rest
+* text=auto

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
 FROM alpine:3.20.2
 
-CMD [ "/usr/bin/svnserve", "--daemon", "--foreground", "--root", "/var/opt/svn" ]
 EXPOSE 3690
+
 HEALTHCHECK CMD netstat -ln | grep 3690 || exit 1
+
 VOLUME [ "/var/opt/svn" ]
 WORKDIR /var/opt/svn
+
+ENV SVNSERVE_ARGS=
 
 RUN apk add --no-cache \
 	subversion==1.14.3-r2 \
 	wget==1.24.5-r0
+
+COPY docker-entrypoint.sh /
+CMD [ "/docker-entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,33 @@ services:
       - /home/svn:/var/opt/svn
 ```
 
+### Start the Subversion server with custom arguments
+
+To define arguments to be passed to the Subversion server, set the `SVNSERVE_ARGS` environmental variable:
+
+#### ...via `docker run`
+
+```sh
+docker run ... SVNSERVE_ARGS="--option1 value1 --option2 value2" ... garethflowers/svn-server
+```
+
+#### ...via `docker compose`
+
+```sh
+services:
+  svn:
+    image: garethflowers/svn-server
+    environment:
+      - SVNSERVE_ARGS=--option1 value1 --option2 value2
+    ...
+```
+
+### List available command line options
+
+```sh
+docker exec -it CONTAINER_NAME svnserve --help
+```
+
 ### Creating a new SVN Repository
 
 Use `svnadmin` within your container to create and manage repositories.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+/usr/bin/svnserve --daemon --foreground --root /var/opt/svn $SVNSERVE_ARGS


### PR DESCRIPTION
`svnserve` has command line options (e.g. `--single-thread`, `--threads`, etc.) that the user might want to set. Could be useful to expose an environmental variable that gets passed to `svnserve` as arguments.